### PR TITLE
Nit: 'a' to 'an'

### DIFF
--- a/image-capture/README.md
+++ b/image-capture/README.md
@@ -1,0 +1,5 @@
+Image Capture Samples
+===
+See https://googlechrome.github.io/samples/image-capture/index.html to browse all Image Capture samples.  
+
+Learn more at https://www.chromestatus.com/features/4843864737185792

--- a/image-capture/grab-frame-take-photo.css
+++ b/image-capture/grab-frame-take-photo.css
@@ -1,0 +1,31 @@
+#results {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#results > div {
+  width: 33%;
+  text-align: center;
+  line-height: 24px;
+}
+
+@media (max-width: 814px) {
+
+  #results {
+    flex-flow: column;
+  }
+  
+  #results > div {
+    width: 100%;
+    margin-bottom: 24px;
+  }
+
+}
+
+video, canvas {
+  border: 2px solid rgba(255, 255, 255, 1);
+  background: #263238;
+  height: 198px;
+  width: 100%;
+}

--- a/image-capture/grab-frame-take-photo.html
+++ b/image-capture/grab-frame-take-photo.html
@@ -10,7 +10,7 @@ index: index.html
 <h3>Background</h3>
 <p>The ImageCapture Web API allows web developers to capture images from a
 photographic device such as a webcam in the form of a Blob with
-<code>takePhoto()</code> or as a ImageBitmap with <code>grabFrame()</code>.</p>
+<code>takePhoto()</code> or as an ImageBitmap with <code>grabFrame()</code>.</p>
 
 <div id='results'>
   <div>

--- a/image-capture/grab-frame-take-photo.html
+++ b/image-capture/grab-frame-take-photo.html
@@ -1,0 +1,38 @@
+---
+feature_name: Image Capture / Grab Frame - Take Photo
+chrome_version: 56
+feature_id: 4843864737185792
+local_css_files: ['grab-frame-take-photo.css']
+check_min_version: true
+index: index.html
+---
+
+<h3>Background</h3>
+<p>The ImageCapture Web API allows web developers to capture images from a
+photographic device such as a webcam in the form of a Blob with
+<code>takePhoto()</code> or as a ImageBitmap with <code>grabFrame()</code>.</p>
+
+<div id='results'>
+  <div>
+    <video autoplay></video>
+    <button id='getUserMediaButton'>Get User Media</button>
+  </div>
+  <div>
+    <canvas id='grabFrameCanvas'></canvas>
+    <button id='grabFrameButton' disabled>Grab Frame</button>
+  </div>
+  <div>
+    <canvas id='takePhotoCanvas'></canvas>
+    <button id='takePhotoButton' disabled>Take Photo</button>
+  </div>
+</div>
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='grab-frame-take-photo.js' %}
+
+<script>
+  document.querySelector('#getUserMediaButton').addEventListener('click', onGetUserMediaButtonClick);
+  document.querySelector('#grabFrameButton').addEventListener('click', onGrabFrameButtonClick);
+  document.querySelector('#takePhotoButton').addEventListener('click', onTakePhotoButtonClick);
+</script>

--- a/image-capture/grab-frame-take-photo.js
+++ b/image-capture/grab-frame-take-photo.js
@@ -1,0 +1,45 @@
+var imageCapture;
+
+function onGetUserMediaButtonClick() {
+  navigator.mediaDevices.getUserMedia({video: true})
+  .then(mediaStream => {
+    document.querySelector('video').srcObject = mediaStream;
+
+    const track = mediaStream.getVideoTracks()[0];
+    imageCapture = new ImageCapture(track);
+  })
+  .catch(error => ChromeSamples.log(error));
+}
+
+function onGrabFrameButtonClick() {
+  imageCapture.grabFrame()
+  .then(imageBitmap => {
+    const canvas = document.querySelector('#grabFrameCanvas');
+    drawCanvas(canvas, imageBitmap);
+  })
+  .catch(error => ChromeSamples.log(error));
+}
+
+function onTakePhotoButtonClick() {
+  imageCapture.takePhoto()
+  .then(blob => createImageBitmap(blob))
+  .then(imageBitmap => {
+    const canvas = document.querySelector('#takePhotoCanvas');
+    drawCanvas(canvas, imageBitmap);
+  })
+  .catch(error => ChromeSamples.log(error));
+}
+
+/* Utils */
+
+function drawCanvas(canvas, imageBitmap) {
+  canvas.width = imageBitmap.width;
+  canvas.height = imageBitmap.height;
+  canvas.getContext('2d').drawImage(imageBitmap, 0, 0,
+      imageBitmap.width, imageBitmap.height);
+}
+
+document.querySelector('video').addEventListener('play', function() {
+  document.querySelector('#grabFrameButton').disabled = false;
+  document.querySelector('#takePhotoButton').disabled = false;
+});

--- a/image-capture/index.html
+++ b/image-capture/index.html
@@ -1,0 +1,17 @@
+---
+title: Image Capture Samples
+feature_name: MediaStream Image Capture
+chrome_version: 56
+feature_id: 4843864737185792
+---
+
+<p>The following samples show you some of the ways that you can use the Image
+Capture API.</p>
+
+<p>Note: Starting in Chrome 56, it is also available for trials so that
+websites can use it without any flag.</p>
+
+<h3>Samples</h3>
+
+<p><a href="grab-frame-take-photo.html">Grab Frame - Take Photo</a> - capture images in the form of a Blob or as a ImageBitmap.</p>
+<p><a href="update-camera-zoom.html">Update Camera Zoom</a> - change the zoom setting of the camera.</p>

--- a/image-capture/update-camera-zoom.css
+++ b/image-capture/update-camera-zoom.css
@@ -1,0 +1,10 @@
+video {
+  background: #263238;
+  height: 198px;
+  width: 100%;
+}
+
+input {
+  text-align: center;
+  width: 100%;
+}

--- a/image-capture/update-camera-zoom.html
+++ b/image-capture/update-camera-zoom.html
@@ -1,0 +1,19 @@
+---
+feature_name: Image Capture / Update Camera Zoom
+chrome_version: 56
+feature_id: 4843864737185792
+local_css_files: ['update-camera-zoom.css']
+check_min_version: true
+index: index.html
+---
+
+<h3>Background</h3>
+<p>The ImageCapture Web API allows web developers to change the zoom setting of
+the camera.</p>
+
+<video autoplay></video>
+<input type="range">
+
+{% include output_helper.html %}
+
+{% include js_snippet.html filename='update-camera-zoom.js' %}

--- a/image-capture/update-camera-zoom.js
+++ b/image-capture/update-camera-zoom.js
@@ -1,0 +1,26 @@
+navigator.mediaDevices.getUserMedia({video: true})
+.then(mediaStream => {
+  document.querySelector('video').srcObject = mediaStream;
+
+  const track = mediaStream.getVideoTracks()[0];
+  const imageCapture = new ImageCapture(track);
+
+  return imageCapture.getPhotoCapabilities()
+  .then(photoCapabilities => {
+    // Check whether zoom is supported or not.
+    if (!photoCapabilities.zoom.min && !photoCapabilities.zoom.max) {
+      return Promise.reject('Zoom is not supported by ' + track.label);
+    }
+
+    // Map zoom to a slider element.
+    const input = document.querySelector('input[type="range"]');
+    input.min = photoCapabilities.zoom.min;
+    input.max = photoCapabilities.zoom.max;
+    input.step = photoCapabilities.zoom.step;
+    input.value = photoCapabilities.zoom.current;
+    input.oninput = function(event) {
+      imageCapture.setOptions({zoom: event.target.value});
+    }
+  });
+})
+.catch(error => ChromeSamples.log('Argh!', error.name || error));


### PR DESCRIPTION
a ImageBitmap => an ImageBitmap

Also — I'd also be inclined to change 'photographic device such as a webcam' to 'camera', since the difference between photo and video is meaningful here — and 'webcam' sounds specifically like something from a desktop machine (i.e. not a mobile device camera).